### PR TITLE
Target develop for Dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
Cherry-pick of the `.github/dependabot.yml` file from PR #8 (which merged to `develop`).

Dependabot only reads its config from the **default branch** (`master`), so the copy on `develop` is invisible to it. With this on master, future Dependabot npm PRs will open against `develop`.

After merge: comment `@dependabot recreate` on #7 to retarget the open picomatch PR to develop.