### PR TITLE
Fix countdown jitter and 5m/5m1s start ambiguity

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -263,12 +263,22 @@ function FormatDuration(d) {
     return '?';
   }
 
-  const divisor = d < 3600000 ? [60000, 1000] : [3600000, 60000];
-
+  // Ceil to keep the badge in lock-step with the popup, which also rounds
+  // sub-second remainders up — otherwise the two displays show different
+  // values for the same moment.
+  const totalSeconds = Math.ceil(d / 1000);
   function pad(x) {
     return x < 10 ? '0' + x : x;
   }
-  return Math.floor(d / divisor[0]) + ':' + pad(Math.floor((d % divisor[0]) / divisor[1]));
+
+  if (totalSeconds < 3600) {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return minutes + ':' + pad(seconds);
+  }
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  return hours + ':' + pad(minutes);
 }
 
 // Function to pause YouTube video
@@ -401,8 +411,9 @@ async function UpdateBadges() {
           'text': description
         });
 
-        // Update badge color based on time remaining
-        const secondsRemaining = Math.floor(timeRemaining / 1000);
+        // Match the popup's warning threshold by ceiling sub-second
+        // remainders the same way it does.
+        const secondsRemaining = Math.ceil(timeRemaining / 1000);
         const badgeColor = secondsRemaining <= 30 ? '#ff0000' : '#666666';
         ChromeAPIWrapper.action.setBadgeBackgroundColor({
           'tabId': tabId,
@@ -417,7 +428,7 @@ async function UpdateBadges() {
     console.error('Failed to get alarms:', error);
   }
 }
-setInterval(UpdateBadges, 1000);
+setInterval(UpdateBadges, 250);
 
 // Function to calculate milliseconds until next 10 PM
 function getMillisecondsUntil10PM() {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -189,11 +189,9 @@ const initPopup = function() {
   }
 
   function getCloseTimeInSeconds() {
-    // Keep +1s so the UI starts with a visible ticking second
     let seconds = 0;
     seconds += Number($minutes[0].value * 60);
     seconds += Number($hours[0].value * 60 * 60);
-    seconds++;
     return seconds;
   }
 
@@ -207,10 +205,12 @@ const initPopup = function() {
   }
 
   function displayTime(distance) {
-    const days = Math.floor(distance / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)) + (days * 24);
-    const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-    const seconds = Math.floor((distance % (1000 * 60)) / 1000);
+    // Ceil so a freshly-set N-minute timer reads "Nm 0s" until a full second
+    // has elapsed, instead of varying with sub-second render jitter.
+    const totalSeconds = Math.max(0, Math.ceil(distance / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
 
     $timeRemaining.html(
       hours + '<span class="t-unit">h</span> ' +
@@ -218,7 +218,6 @@ const initPopup = function() {
       seconds + '<span class="t-unit">s</span>'
     );
 
-    const totalSeconds = hours * 3600 + minutes * 60 + seconds;
     if (totalSeconds <= 30) {
       $timeRemaining.addClass('warning');
     } else {
@@ -262,9 +261,10 @@ const initPopup = function() {
       }
     }
 
-    // Initial update and interval
+    // Sub-second sampling so interval drift can't push transitions a whole
+    // second late and make the display stick or skip.
     updateCountdown();
-    window.countdownInterval = setInterval(updateCountdown, 1000);
+    window.countdownInterval = setInterval(updateCountdown, 250);
 
     // Update ETA only if countdown is in the future (and not paused)
     if (!isPaused && countDownDate && countDownDate > Date.now()) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -660,12 +660,11 @@ describe('Background Script Utility Functions', () => {
         let seconds = 0;
         seconds += Number($('#minutes')[0].value * 60);
         seconds += Number($('#hours')[0].value * 60 * 60);
-        seconds++;
         return seconds;
       };
 
       const result = getCloseTimeInSeconds();
-      expect(result).toBe(5401); // 1 hour + 30 minutes + 1 second
+      expect(result).toBe(5400); // 1 hour + 30 minutes
     });
   });
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -49,6 +49,15 @@ describe('Background Script Utility Functions', () => {
     test('formats very large durations correctly', () => {
       expect(FormatDuration(72000000)).toBe('20:00'); // 20 hours
     });
+
+    // Sub-second remainders ceil up so the badge agrees with the popup
+    // (which also uses Math.ceil).
+    test('ceils sub-second remainders to match popup display', () => {
+      expect(FormatDuration(299999)).toBe('5:00'); // 4m 59.999s -> 5:00
+      expect(FormatDuration(299500)).toBe('5:00'); // 4m 59.5s -> 5:00
+      expect(FormatDuration(299000)).toBe('4:59'); // exactly one full second below 5m
+      expect(FormatDuration(4500)).toBe('0:05');   // 4.5s -> 0:05
+    });
   });
 
   /**

--- a/tests/popup.integration.test.js
+++ b/tests/popup.integration.test.js
@@ -268,6 +268,27 @@ describe('popup.js integration coverage', () => {
     expect($('#eta').text()).toBe('');
   });
 
+  test('a fresh 5-minute alarm renders as "5m 0s", not "4m 59s" or "5m 1s"', async() => {
+    await loadPopup({ alarm: { scheduledTime: Date.now() + 5 * 60 * 1000 } });
+    expect($('#timeRemaining').text()).toBe('0h 5m 0s');
+  });
+
+  test('displayTime ceils sub-second remainders so 4.5s renders as 5s', async() => {
+    await loadPopup({ alarm: { scheduledTime: Date.now() + 4500 } });
+    expect($('#timeRemaining').text()).toBe('0h 0m 5s');
+  });
+
+  test('countdown samples sub-second so display can\'t stick or skip', async() => {
+    const setSpy = jest.spyOn(global, 'setInterval');
+    await loadPopup({ alarm: { scheduledTime: Date.now() + 60000 } });
+    const countdownCalls = setSpy.mock.calls.filter(
+      ([, delay]) => delay !== 1000 // jest internal intervals run at 1s; ignore those
+    );
+    expect(countdownCalls.length).toBeGreaterThan(0);
+    expect(countdownCalls.every(([, delay]) => delay <= 250)).toBe(true);
+    setSpy.mockRestore();
+  });
+
   test('YouTube tabs reveal action options, default to pause, and persist selection', async() => {
     const { tab } = await loadPopup({
       url: 'https://www.youtube.com/watch?v=abc123'

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -314,12 +314,11 @@ describe('Popup Script Functionality', () => {
         let seconds = 0;
         seconds += Number(document.getElementById('minutes').value * 60);
         seconds += Number(document.getElementById('hours').value * 60 * 60);
-        seconds++;
         return seconds;
       };
 
       const result = getCloseTimeInSeconds();
-      expect(result).toBe(5401); // 1 hour (3600) + 30 minutes (1800) + 1 second
+      expect(result).toBe(5400); // 1 hour (3600) + 30 minutes (1800)
     });
 
     test('input validation should work correctly', () => {


### PR DESCRIPTION
## Symptoms
- A 5-minute timer sometimes opens at "5m 0s", sometimes at "5m 1s".
- The countdown sometimes ticks down by 2 seconds at once, or appears to stick on the same value for 2 seconds.
- The icon badge and the popup display are slightly out of sync.

## Root causes
Five compounding bugs across `popup/popup.js` and `background/background.js`:

1. **`getCloseTimeInSeconds` added `seconds++`** — alarm scheduled 1s past requested duration.
2. **`displayTime` used `Math.floor`** on the seconds slice — 4.999s remaining displayed as "4s".
3. **`setInterval(updateCountdown, 1000)`** — browser jitter routinely delayed the 1s tick by 100–300ms; with floor rounding, two ticks landed in the same integer second (display sticks) or skipped one (decrements by 2).
4. **`FormatDuration` (badge) used `Math.floor`** — out of sync with the popup's ceil math by exactly one full second across most of the countdown.
5. **`UpdateBadges` ran on a 1000ms interval** — same drift problem as the popup, exacerbating the desync.

## Fix
- Drop `seconds++` so the alarm matches the requested duration exactly.
- Compute `totalSeconds` once via `Math.ceil(distance / 1000)` and derive h/m/s from it, in both popup and badge.
- Sample popup and badge at 250ms instead of 1000ms.
- Use ceil for the badge color threshold (≤30s → red) so it crosses at the same instant as the popup's "warning" class.

## Tests
- Updated existing `getCloseTimeInSeconds` expectations (5401 → 5400) in `tests/popup.test.js` and `tests/background.test.js`.
- 4 new tests:
  - 5-minute alarm renders as "0h 5m 0s" right after start (popup)
  - 4.5s remaining renders as "0h 0m 5s" (popup, ceil)
  - countdown's `setInterval` delay is ≤ 250ms (popup)
  - `FormatDuration` ceils sub-second remainders, e.g. 299999ms → "5:00" (badge)

## Verification
- [x] `npm test` — 165/165, coverage 95% lines
- [x] `npm run lint` clean
- [x] `npm run validate` clean
- [x] `npm run security-audit` — 0 vulnerabilities
- [x] `npm run build` succeeds
- [ ] CI passes on push
- [ ] Manual smoke (load via `chrome://extensions`, set 5m timer, confirm popup and badge stay in lock-step)