### PR TITLE
Forward release pipeline fix to master for v1.4.0 retag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,26 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
-        
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Get version from manifest
         id: get_version
         run: |
           VERSION=$(grep -Po '(?<="version": ")[^"]*' manifest.json)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-        
+
       - name: Validate version consistency
         run: |
           RELEASE_VERSION=${{ github.event.release.tag_name }}
@@ -35,40 +35,37 @@ jobs:
             echo "Version mismatch: Release tag $RELEASE_VERSION vs manifest $MANIFEST_VERSION"
             exit 1
           fi
-        
+
       - name: Run full test suite
         run: npm run test:coverage
-      
+
       - name: Build production bundle
         run: npm run build
-      
+
       - name: Verify build artifact
         run: test -f "TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip"
-        
-      - name: Upload release asset to GitHub
-        uses: actions/upload-release-asset@v1
+
+      - name: Attach build artifact to release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip
-          asset_name: TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip
-          asset_content_type: application/zip
-        
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip" \
+            --clobber
+
       - name: Upload to Chrome Web Store
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: fregante/chrome-webstore-upload-cli@v2
+        uses: wdzeng/chrome-extension@v1
         with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          zip-path: TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip
           client-id: ${{ secrets.CHROME_CLIENT_ID }}
           client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
           refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
-          zip: TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip
-        
+
       - name: Upload to Edge Add-ons
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: wzieba/Edge-Addons-Upload@v1
+        uses: wdzeng/edge-addon@v2
         with:
           product-id: ${{ secrets.EDGE_PRODUCT_ID }}
           zip-path: TabCountdownTimer_${{ steps.get_version.outputs.version }}.zip
-          dev-token: ${{ secrets.EDGE_DEV_TOKEN }}
+          api-key: ${{ secrets.EDGE_API_KEY }}
+          client-id: ${{ secrets.EDGE_CLIENT_ID }}


### PR DESCRIPTION
Forwards #17 (release pipeline fix) from `develop` to `master` so we can retag `v1.4.0` at a master commit that includes the fixed `release.yml`.

Required follow-up: `v1.4.0` tag and GitHub release will be deleted and recreated at master HEAD after this merges. New Edge secrets (`EDGE_API_KEY`, `EDGE_CLIENT_ID`) required for the next release pipeline run.